### PR TITLE
ClAYG decoder

### DIFF
--- a/src/qiskit_qec/decoders/__init__.py
+++ b/src/qiskit_qec/decoders/__init__.py
@@ -34,4 +34,4 @@ from .decoding_graph import DecodingGraph
 from .circuit_matching_decoder import CircuitModelMatchingDecoder
 from .repetition_decoder import RepetitionDecoder
 from .three_bit_decoder import ThreeBitDecoder
-from .hdrg_decoders import BravyiHaahDecoder, UnionFindDecoder
+from .hdrg_decoders import BravyiHaahDecoder, UnionFindDecoder, ClAYGDecoder

--- a/src/qiskit_qec/decoders/decoding_graph.py
+++ b/src/qiskit_qec/decoders/decoding_graph.py
@@ -40,7 +40,7 @@ class DecodingGraph:
     METHOD_NAIVE: str = "naive"
     AVAILABLE_METHODS = {METHOD_SPITZ, METHOD_NAIVE}
 
-    def __init__(self, code, brute=False):
+    def __init__(self, code, brute=False, graph=None):
         """
         Args:
             code (CodeCircuit): The QEC code circuit object for which this decoding
@@ -52,7 +52,10 @@ class DecodingGraph:
         self.code = code
         self.brute = brute
 
-        self._make_syndrome_graph()
+        if graph:
+            self.graph = graph
+        else:
+            self._make_syndrome_graph()
 
     def _make_syndrome_graph(self):
         if not self.brute and hasattr(self.code, "_make_syndrome_graph"):

--- a/src/qiskit_qec/decoders/hdrg_decoders.py
+++ b/src/qiskit_qec/decoders/hdrg_decoders.py
@@ -18,7 +18,7 @@
 
 from copy import copy, deepcopy
 from dataclasses import dataclass
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Tuple
 from rustworkx import connected_components, distance_matrix, PyGraph
 
 from qiskit_qec.circuits.repetition_code import ArcCircuit, RepetitionCodeCircuit
@@ -268,6 +268,7 @@ class UnionFindDecoderCluster:
 
     boundary: List[BoundaryEdge]
     atypical_nodes: Set[int]
+    nodes: Set[int]
     fully_grown_edges: Set[int]
     size: int
 
@@ -304,8 +305,8 @@ class UnionFindDecoder(ClusteringDecoder):
         super().__init__(code, decoding_graph)
         self.logical = logical
         self.graph = deepcopy(self.decoding_graph.graph)
-        self.clusters: List[List[int]] = []
-        self.odd_cluster_roots: Set[int] = []
+        self.clusters: Dict[int, UnionFindDecoderCluster] = {}
+        self.odd_cluster_roots: Set[int] = set()
 
     def process(self, string: str):
         """
@@ -327,8 +328,8 @@ class UnionFindDecoder(ClusteringDecoder):
             return output  # There's nothing for us to do here
         clusters = self.cluster(highlighted_nodes)
 
-        for cluster in clusters:
-            erasure = self.graph.subgraph(cluster)
+        for cluster_nodes, _ in clusters:
+            erasure = self.graph.subgraph(cluster_nodes)
             if isinstance(self.code, ArcCircuit):
                 # NOTE: it just corrects for final logical readout
                 for node in erasure.nodes():
@@ -368,34 +369,27 @@ class UnionFindDecoder(ClusteringDecoder):
 
         self.clusters: Dict[int, UnionFindDecoderCluster] = {}
         self.odd_cluster_roots = set(node_indices)
-        for node_index in self.graph.node_indices():
+        for node_index in node_indices:
             boundary_edges = []
-            for edge_index, (_, neighbour, data) in dict(
-                self.graph.incident_edge_index_map(node_index)
-            ).items():
+            for edge_index, neighbour, data in self.neighbouring_edges(node_index):
                 boundary_edges.append(BoundaryEdge(edge_index, node_index, neighbour, data))
             self.clusters[node_index] = UnionFindDecoderCluster(
                 boundary=boundary_edges,
                 fully_grown_edges=set(),
-                atypical_nodes=set([node_index])
-                if node_index in self.odd_cluster_roots
-                else set([]),
+                atypical_nodes=set([node_index]),
+                nodes=set([node_index]),
                 size=1,
             )
 
         while self.odd_cluster_roots:
-            fusion_edge_list = self._grow_clusters()
-            self._merge_clusters(fusion_edge_list)
+            self._grow_and_merge_clusters()
 
-        cluster_nodes = []
+        clusters = []
         for _, cluster in self.clusters.items():
             if not cluster.atypical_nodes:
                 continue
-            nodes = set()
-            for edge in cluster.fully_grown_edges:
-                nodes |= set(self.graph.get_edge_endpoints_by_index(edge))
-            cluster_nodes.append(list(nodes))
-        return cluster_nodes
+            clusters.append((list(cluster.nodes), list(cluster.atypical_nodes)))
+        return clusters
 
     def find(self, u: int) -> int:
         """
@@ -414,6 +408,10 @@ class UnionFindDecoder(ClusteringDecoder):
         self.graph[u].properties["root"] = self.find(self.graph[u].properties["root"])
         return self.graph[u].properties["root"]
 
+    def _grow_and_merge_clusters(self) -> Set[int]:
+        fusion_edge_list = self._grow_clusters()
+        return self._merge_clusters(fusion_edge_list)
+
     def _grow_clusters(self) -> List[FusionEntry]:
         """
         Grow every "odd" cluster by half an edge.
@@ -431,6 +429,26 @@ class UnionFindDecoder(ClusteringDecoder):
                     edge.data.properties["growth"] >= edge.data.weight
                     and not edge.data.properties["fully_grown"]
                 ):
+                    neighbour_root = self.find(edge.neighbour_vertex)
+                    if not neighbour_root in self.clusters:
+                        boundary_edges = []
+                        for edge_index, neighbour_neighbour, data in self.neighbouring_edges(
+                            edge.neighbour_vertex
+                        ):
+                            boundary_edges.append(
+                                BoundaryEdge(
+                                    edge_index, edge.neighbour_vertex, neighbour_neighbour, data
+                                )
+                            )
+                        self.graph[edge.neighbour_vertex].properties["root"] = edge.neighbour_vertex
+                        self.clusters[edge.neighbour_vertex] = UnionFindDecoderCluster(
+                            boundary=boundary_edges,
+                            fully_grown_edges=set(),
+                            atypical_nodes=set(),
+                            nodes=set([edge.neighbour_vertex]),
+                            size=1,
+                        )
+                    edge.data.properties["growth"] = 0
                     edge.data.properties["fully_grown"] = True
                     cluster.fully_grown_edges.add(edge.index)
                     fusion_entry = FusionEntry(
@@ -439,7 +457,7 @@ class UnionFindDecoder(ClusteringDecoder):
                     fusion_edge_list.append(fusion_entry)
         return fusion_edge_list
 
-    def _merge_clusters(self, fusion_edge_list: List[FusionEntry]) -> None:
+    def _merge_clusters(self, fusion_edge_list: List[FusionEntry]):
         """
         Merges the clusters based on the fusion_edge_list computed in _grow_clusters().
         Updates the odd_clusters list by recomputing the neutrality of the newly merged clusters.
@@ -447,6 +465,8 @@ class UnionFindDecoder(ClusteringDecoder):
         Args:
             fusion_edge_list (List[FusionEntry]): List of edges that connect two
             clusters that was computed in _grow_clusters().
+        Returns:
+            new_neutral_cluster_roots (List[int]): List of roots of newly neutral clusters
         """
         for entry in fusion_edge_list:
             root_u, root_v = self.find(entry.u), self.find(entry.v)
@@ -463,6 +483,7 @@ class UnionFindDecoder(ClusteringDecoder):
             cluster.boundary.remove(entry.connecting_edge)
             cluster.boundary.remove(entry.connecting_edge.reverse())
 
+            cluster.nodes |= other_cluster.nodes
             cluster.atypical_nodes |= other_cluster.atypical_nodes
             cluster.fully_grown_edges |= other_cluster.fully_grown_edges
             cluster.size += other_cluster.size
@@ -499,11 +520,15 @@ class UnionFindDecoder(ClusteringDecoder):
         # Construct spanning forest
         # Pick starting vertex
         for vertex in erasure.node_indices():
-            if erasure[vertex].is_boundary:
+            if erasure[vertex].is_boundary and erasure[vertex].properties["syndrome"]:
                 tree.vertices[vertex] = []
                 break
+
         if not tree.vertices:
-            tree.vertices[erasure.node_indices()[0]] = []
+            for vertex in erasure.node_indices():
+                if erasure[vertex].properties["syndrome"]:
+                    tree.vertices[vertex] = []
+                    break
 
         # Expand forest |V| - 1 times, constructing it
         while len(tree.edges) < len(erasure.nodes()) - 1:
@@ -524,10 +549,7 @@ class UnionFindDecoder(ClusteringDecoder):
             pendant_vertex = endpoints[0] if not tree.vertices[endpoints[0]] else endpoints[1]
             tree_vertex = endpoints[0] if pendant_vertex == endpoints[1] else endpoints[1]
             tree.vertices[tree_vertex].remove(edge)
-            if (
-                erasure[pendant_vertex].properties["syndrome"]
-                and not erasure[pendant_vertex].is_boundary
-            ):
+            if erasure[pendant_vertex].properties["syndrome"]:
                 edges.add(edge)
                 erasure[tree_vertex].properties["syndrome"] = not erasure[tree_vertex].properties[
                     "syndrome"
@@ -535,3 +557,177 @@ class UnionFindDecoder(ClusteringDecoder):
                 erasure[pendant_vertex].properties["syndrome"] = False
 
         return [erasure.edges()[edge].qubits[0] for edge in edges if erasure.edges()[edge].qubits]
+
+    def neighbouring_edges(self, node_index) -> List[Tuple[int, int, DecodingGraphEdge]]:
+        """
+        Returns all of the neighbouring edges of a node in the decoding graph.
+        Args:
+            node_index (int): The index of the node in the graph.
+
+        Returns:
+            neighbouring_edges (List[Tuple[int, int, DecodingGraphEdge]]): List of neighbouring edges
+            in following format: (
+                index of edge in graph,
+                index of neighbour node in graph,
+                data payload of the edge
+            )
+        """
+        return [
+            (edge, neighbour, data)
+            for edge, (_, neighbour, data) in dict(
+                self.graph.incident_edge_index_map(node_index)
+            ).items()
+        ]
+
+
+class ClAYGDecoder(UnionFindDecoder):
+    """
+    Decoder that is very similar to the Union Find decoder, but instead of adding clusters all at once,
+    adds them separated by syndrome round with a growth and merge phase in between.
+    Then it just proceeds like the Union Find decoder.
+
+    FIXME: Use the Union Find infrastructure and just change the self.cluster() method. Problem is that
+    the peeling decoder needs a modified version the graph with the syndrome nodes marked, which is done
+    in the process method. For now it is mostly its separate thing, but merging them shouldn't be
+    too big of a hassle.
+    Merge method should also be modified, as boundary clusters are not marked as odd clusters.
+    """
+
+    def __init__(self, code, logical: str, decoding_graph: DecodingGraph = None) -> None:
+        super().__init__(code, logical, decoding_graph)
+        self.graph = deepcopy(self.decoding_graph.graph)
+        self.r = 1
+
+    def process(self, string: str):
+        """
+        Process an output string and return corrected final outcomes.
+
+        Args:
+            string (str): Output string of the code.
+        Returns:
+            corrected_z_logicals (list): A list of integers that are 0 or 1.
+        These are the corrected values of the final transversal
+        measurement, corresponding to the logical operators of
+        self.z_logicals.
+        """
+
+        nodes_at_time_zero = []
+        for index, node in zip(
+            self.decoding_graph.graph.node_indices(), self.decoding_graph.graph.nodes()
+        ):
+            if node.time == 0 or node.is_boundary:
+                nodes_at_time_zero.append(index)
+        self.graph = self.decoding_graph.graph.subgraph(nodes_at_time_zero)
+        for index, node in zip(self.graph.node_indices(), self.graph.nodes()):
+            node.properties["root"] = index
+        for edge in self.graph.edges():
+            edge.properties["growth"] = 0
+            edge.properties["fully_grown"] = False
+
+        string = "".join([str(c) for c in string[::-1]])
+        output = [int(bit) for bit in list(string.split(" ", maxsplit=self.code.d)[0])][::-1]
+        highlighted_nodes = self.code.string2nodes(string, logical=self.logical)
+        if not highlighted_nodes:
+            return output  # There's nothing for us to do here
+
+        clusters = self.cluster(highlighted_nodes)
+
+        flattened_highlighted_nodes: List[DecodingGraphNode] = []
+        for highlighted_node in highlighted_nodes:
+            highlighted_node.time = 0
+            flattened_highlighted_nodes.append(self.graph.nodes().index(highlighted_node))
+
+        for cluster_nodes, cluster_atypical_nodes in clusters:
+            if not cluster_nodes:
+                continue
+            erasure_graph = deepcopy(self.graph)
+            for node in cluster_nodes:
+                erasure_graph[node].properties["syndrome"] = node in cluster_atypical_nodes
+            erasure = erasure_graph.subgraph(cluster_nodes)
+            qubits_to_be_corrected = self.peeling(erasure)
+            for idx in qubits_to_be_corrected:
+                output[idx] = (output[idx] + 1) % 2
+
+        return output
+
+    def cluster(self, nodes: List[DecodingGraphNode]):
+        self.clusters: Dict[int, UnionFindDecoderCluster] = {}
+        self.odd_cluster_roots = set()
+
+        times: List[List[DecodingGraphNode]] = [[] for _ in range(self.code.T + 1)]
+        boundaries = []
+        for node in deepcopy(nodes):
+            if node.is_boundary:
+                boundaries.append(node)
+            else:
+                times[node.time].append(node)
+                node.time = 0
+
+        neutral_clusters = []
+
+        for node in boundaries:
+            self._add_node(node, create_new_cluster=False)
+
+        for time in times:
+            for node in time:
+                self._add_node(node)
+            for _ in range(self.r):
+                self._grow_and_merge_clusters()
+            neutral_clusters += self._collect_neutral_clusters()
+
+        while self.odd_cluster_roots:
+            self._grow_and_merge_clusters()
+
+        neutral_clusters += self._collect_neutral_clusters()
+
+        neutral_cluster_nodes: List[List[int]] = []
+        for cluster in neutral_clusters:
+            neutral_cluster_nodes.append((list(cluster.nodes), list(cluster.atypical_nodes)))
+
+        return neutral_cluster_nodes
+
+    def _add_node(
+        self, node, create_new_cluster=True
+    ):  # FIXME: Do we actually need to not grow boundary clusters?
+        node_index = self.graph.nodes().index(node)
+        root = self.find(node_index)
+        cluster = self.clusters.get(root)
+        if cluster:
+            # Add the node to the cluster or remove it if it's already present
+            if node_index in cluster.atypical_nodes:
+                cluster.atypical_nodes.remove(node_index)
+            else:
+                cluster.atypical_nodes.add(node_index)
+        else:
+            # Create a new cluster
+            boundary_edges = []
+            for edge_index, neighbour_neighbour, data in self.neighbouring_edges(node_index):
+                boundary_edges.append(
+                    BoundaryEdge(edge_index, node_index, neighbour_neighbour, data)
+                )
+            self.graph[node_index].properties["root"] = node_index
+            self.clusters[node_index] = UnionFindDecoderCluster(
+                boundary=boundary_edges,
+                fully_grown_edges=set(),
+                atypical_nodes=set([node_index]),
+                nodes=set([node_index]),
+                size=1,
+            )
+            if create_new_cluster:
+                self.odd_cluster_roots.add(node_index)
+
+    def _collect_neutral_clusters(self):
+        neutral_clusters = []
+        for root, cluster in self.clusters.copy().items():
+            if self.code.is_cluster_neutral([self.graph[u] for u in cluster.atypical_nodes]):
+                self.odd_cluster_roots.discard(root)
+                cluster = self.clusters.pop(root)
+                if cluster.atypical_nodes:
+                    neutral_clusters.append(cluster)
+                for edge in cluster.fully_grown_edges:
+                    self.graph.edges()[edge].properties["fully_grown"] = False
+                for edge in cluster.boundary:
+                    self.graph.edges()[edge.index].properties["growth"] = 0
+                for node in cluster.nodes:
+                    self.graph[node].properties["root"] = node
+        return neutral_clusters

--- a/src/qiskit_qec/decoders/hdrg_decoders.py
+++ b/src/qiskit_qec/decoders/hdrg_decoders.py
@@ -306,7 +306,10 @@ class UnionFindDecoder(ClusteringDecoder):
         self.logical = logical
         self.graph = deepcopy(self.decoding_graph.graph)
         self.clusters: Dict[int, UnionFindDecoderCluster] = {}
-        self.odd_cluster_roots: Set[int] = set()
+        # FIXME: Use a better datastructure
+        # It needs to support inserting at specific index, unique elements and
+        # sorted insert
+        self.odd_cluster_roots: List[int] = []
 
     def process(self, string: str):
         """
@@ -368,7 +371,7 @@ class UnionFindDecoder(ClusteringDecoder):
             edge.properties["fully_grown"] = False
 
         self.clusters: Dict[int, UnionFindDecoderCluster] = {}
-        self.odd_cluster_roots = set(node_indices)
+        self.odd_cluster_roots = node_indices
         for node_index in node_indices:
             boundary_edges = []
             for edge_index, neighbour, data in self.neighbouring_edges(node_index):
@@ -492,11 +495,17 @@ class UnionFindDecoder(ClusteringDecoder):
             if not self.code.is_cluster_neutral(
                 [self.graph[node] for node in cluster.atypical_nodes]
             ):
-                self.odd_cluster_roots.add(new_root)
+                if not new_root in self.odd_cluster_roots:
+                    self.odd_cluster_roots.append(new_root)
             else:
-                self.odd_cluster_roots.discard(new_root)
-            self.odd_cluster_roots.discard(root_to_update)
+                if new_root in self.odd_cluster_roots:
+                    self.odd_cluster_roots.remove(new_root)
+            if root_to_update in self.odd_cluster_roots:
+                self.odd_cluster_roots.remove(root_to_update)
             self.graph[root_to_update].properties["root"] = new_root
+            self.odd_cluster_roots = sorted(
+                self.odd_cluster_roots, key=lambda c: self.clusters[c].size
+            )
 
     def peeling(self, erasure: PyGraph) -> List[int]:
         """ "
@@ -652,7 +661,7 @@ class ClAYGDecoder(UnionFindDecoder):
 
     def cluster(self, nodes: List[DecodingGraphNode]):
         self.clusters: Dict[int, UnionFindDecoderCluster] = {}
-        self.odd_cluster_roots = set()
+        self.odd_cluster_roots = []
 
         times: List[List[DecodingGraphNode]] = [[] for _ in range(self.code.T + 1)]
         boundaries = []
@@ -714,13 +723,14 @@ class ClAYGDecoder(UnionFindDecoder):
                 size=1,
             )
             if create_new_cluster:
-                self.odd_cluster_roots.add(node_index)
+                self.odd_cluster_roots.insert(0, node_index)
 
     def _collect_neutral_clusters(self):
         neutral_clusters = []
         for root, cluster in self.clusters.copy().items():
             if self.code.is_cluster_neutral([self.graph[u] for u in cluster.atypical_nodes]):
-                self.odd_cluster_roots.discard(root)
+                if root in self.odd_cluster_roots:
+                    self.odd_cluster_roots.remove(root)
                 cluster = self.clusters.pop(root)
                 if cluster.atypical_nodes:
                     neutral_clusters.append(cluster)

--- a/test/union_find/test_clayg.py
+++ b/test/union_find/test_clayg.py
@@ -1,0 +1,196 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for template."""
+
+import math
+import random
+import unittest
+from qiskit_qec.analysis.faultenumerator import FaultEnumerator
+from qiskit_qec.decoders import ClAYGDecoder
+from qiskit_qec.circuits import SurfaceCodeCircuit, RepetitionCodeCircuit
+from qiskit_qec.decoders.temp_code_util import temp_syndrome
+from qiskit_qec.noise.paulinoisemodel import PauliNoiseModel
+
+
+def flip_with_probability(p, val):
+    """
+    Flips parity of val with probability p.
+    """
+    if random.random() <= p:
+        val = (val + 1) % 2
+    return val
+
+
+def noisy_surface_code_outcome(d, p):
+    """
+    Generates outcome for surface code with phenomenological noise built in.
+    """
+    string = ""
+    qubits = [0 for _ in range(d**2)]
+    for _ in range(d):
+        for qubit in qubits:
+            qubit = flip_with_probability(p, qubit)
+        # Top ancillas
+        for i in [2 * i for i in range((d - 1) // 2)]:
+            ancilla = (qubits[i] + qubits[i + 1]) % 2
+            ancilla = flip_with_probability(p, ancilla)
+            string += str(ancilla)
+        for row in range(d - 1):
+            offset = (row + 1) % 2
+            for topleft in [offset + row * d + 2 * i for i in range((d - 1) // 2)]:
+                ancilla = (
+                    qubits[topleft]
+                    + qubits[topleft + 1]
+                    + qubits[topleft + d]
+                    + qubits[topleft + d + 1]
+                ) % 2
+                ancilla = flip_with_probability(p, ancilla)
+                string += str(ancilla)
+        for i in [d * (d - 1) + 1 + 2 * i for i in range((d - 1) // 2)]:
+            ancilla = (qubits[i] + qubits[i + 1]) % 2
+            ancilla = flip_with_probability(p, ancilla)
+            string += str(ancilla)
+        string += " "
+    for qubit in qubits:
+        qubit = flip_with_probability(p, qubit)
+        string += str(qubit)
+    return string
+
+
+class ClAYGDecoderTest(unittest.TestCase):
+    """Tests will be here."""
+
+    def setUp(self) -> None:
+        # Bit-flip circuit noise model
+        p = 0.05
+        noise_model = PauliNoiseModel()
+        noise_model.add_operation("cx", {"ix": 1, "xi": 1, "xx": 1})
+        noise_model.add_operation("id", {"x": 1})
+        noise_model.add_operation("reset", {"x": 1})
+        noise_model.add_operation("measure", {"x": 1})
+        noise_model.add_operation("x", {"x": 1, "y": 1, "z": 1})
+        noise_model.set_error_probability("cx", p)
+        noise_model.set_error_probability("x", p)
+        noise_model.set_error_probability("id", p)
+        noise_model.set_error_probability("reset", p)
+        noise_model.set_error_probability("measure", p)
+        self.noise_model = noise_model
+
+        self.fault_enumeration_method = "stabilizer"
+
+        return super().setUp()
+
+    def test_surface_code_d3(self):
+        """
+        Test the ClAYG decoder on a surface code with d=3 and T=3
+        with faults inserted by FaultEnumerator by checking if the syndromes
+        have even parity (if it's a valid code state) and if the logical value measured
+        is the one encoded by the circuit.
+        """
+        for logical in ["0", "1"]:
+            code = SurfaceCodeCircuit(d=3, T=3)
+            decoder = ClAYGDecoder(code, logical)
+
+            fault_enumerator = FaultEnumerator(
+                code.circuit[logical], method=self.fault_enumeration_method, model=self.noise_model
+            )
+            for fault in fault_enumerator.generate():
+                outcome = "".join([str(x) for x in fault[3]])
+                corrected_outcome = decoder.process(outcome)
+                stabilizers = temp_syndrome(corrected_outcome, code.css_z_stabilizer_ops)
+                for syndrome in stabilizers:
+                    self.assertEqual(syndrome, 0)
+                logical_measurement = temp_syndrome(corrected_outcome, [code.css_z_logical])[0]
+                self.assertEqual(str(logical_measurement), logical)
+
+    def test_repetition_code_d5(self):
+        """
+        Test the ClAYG decoder on a repetition code with d=5 and T=5
+        with faults inserted by FaultEnumerator by checking if the syndromes
+        have even parity (if it's a valid code state) and if the logical value measured
+        is the one encoded by the circuit.
+        """
+        for logical in ["0", "1"]:
+            code = RepetitionCodeCircuit(d=5, T=5)
+            decoder = ClAYGDecoder(code, logical)
+            fault_enumerator = FaultEnumerator(
+                code.circuit[logical], method=self.fault_enumeration_method, model=self.noise_model
+            )
+            for fault in fault_enumerator.generate():
+                outcome = "".join([str(x) for x in fault[3]])
+                corrected_outcome = decoder.process(outcome)
+                stabilizers = temp_syndrome(corrected_outcome, code.css_z_stabilizer_ops)
+                for syndrome in stabilizers:
+                    self.assertEqual(syndrome, 0)
+                logical_measurement = temp_syndrome(corrected_outcome, code.css_z_logical)[0]
+                self.assertEqual(str(logical_measurement), logical)
+
+    def test_error_rates(self):
+        """
+        Test the error rates using some ARCs.
+        """
+        d = 8
+        p = 0.01
+        samples = 1000
+
+        testcases = []
+        testcases = [
+            "".join([random.choices(["0", "1"], [1 - p, p])[0] for _ in range(d)])
+            for _ in range(samples)
+        ]
+        codes = self.construct_codes(d)
+
+        # now run them all and check it works
+        for code in codes:
+            decoder = ClAYGDecoder(code, logical="0")
+            z_logicals = code.css_z_logical[0]
+
+            logical_errors = 0
+            min_flips_for_logical = code.d
+            for sample in range(samples):
+                # generate random string
+                string = ""
+                for _ in range(code.T):
+                    string += "0" * (d - 1) + " "
+                string += testcases[sample]
+                # get and check corrected_z_logicals
+                outcome = decoder.process(string)
+                logical_outcome = sum([outcome[int(z_logical / 2)] for z_logical in z_logicals]) % 2
+                if not logical_outcome == 0:
+                    logical_errors += 1
+                    min_flips_for_logical = min(min_flips_for_logical, string.count("1"))
+
+            # check that error rates are at least <p^/2
+            # and that min num errors to cause logical errors >d/3
+            self.assertTrue(
+                logical_errors / samples
+                < (math.factorial(d)) / (math.factorial(int(d / 2)) ** 2) * p**4,
+                "Logical error rate shouldn't exceed d!/((d/2)!^2)*p^(d/2).",
+            )
+            self.assertTrue(
+                min_flips_for_logical >= d / 2,
+                "Minimum amount of errors that also causes logical errors shouldn't be lower than d/2.",
+            )
+
+    def construct_codes(self, d):
+        """
+        Construct codes for the logical error rate test.
+        """
+        codes = []
+        # TODO: Add more codes
+        codes.append(RepetitionCodeCircuit(d=d, T=1))
+        return codes
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a novel decoder to QiskitQEC. At it's core it uses the Union Find decoder, but operates on a two-dimensional slice of the original (2+1)-dimensional decoding graph representing just one syndrome round. 
It does this by adding the nodes to  this slice and checking whether they belong to a cluster. If it does, it "flips" the node in the cluster. If not it starts a new cluster with the new node as its root. Then the clusters are grown. The amount of growth between each round can be parametrized and depends on the error model.
After having processed every round, it proceeds just like the normal UF decoder until there are no more odd clusters.
It also differs from UF, because after having processed each syndrome round, it removes all neutral clusters from the graph and passes it to the erasure decoder directly, such that it can theoretically run in parallel. 
This redesign has two advantages: It allows the decoder to run parallelly to the computation and it can be easily parallelized to run in O(d) time on O(d^2) computational resources, where the original UF decoder would require O(d^3) resources.
